### PR TITLE
Add simple tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27
+
+[testenv]
+commands = py.test
+deps =
+    pytest


### PR DESCRIPTION
Добавил простейший tox.ini 
(там все генерируется утилитой tox-quickstart)
Тесты проходят только для версии 2.7
На 2.6, 3.3 и pypy ломается.
